### PR TITLE
Fixed hardcode about Fallout 3 in messagebox

### DIFF
--- a/flmm/Games/WorkingDirectorySelectionForm.cs
+++ b/flmm/Games/WorkingDirectorySelectionForm.cs
@@ -107,7 +107,7 @@ namespace Fomm.Games
       }
       else
       {
-        MessageBox.Show(this, "Could not find Fallout 3.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBox.Show(this, "Could not find game directory.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
       }
     }
 


### PR DESCRIPTION
When you try to autofind dir with Fallout New Vegas and cancel it you will get line about Fallout 3.
This PR will fix it.